### PR TITLE
Change log type to Warning (from Error) if AdMob id is not valid

### DIFF
--- a/Editor/PreProcess/AppodealPreProcess.cs
+++ b/Editor/PreProcess/AppodealPreProcess.cs
@@ -108,7 +108,7 @@ namespace AppodealStack.UnityEditor.PreProcess
                 {
                     androidManifest.RemoveAdmobAppId();
                 }
-                Debug.LogError(
+                Debug.LogWarning(
                     $"Admob App ID is not set via 'Appodeal/Appodeal Settings' tool." +
                     "\nThe app may crash on startup!");
             }


### PR DESCRIPTION
Change log type from 'Error' to 'Warning'

When a user has his own build system, he does not need these automations from Appodeal.
 
And in this situation - it is not an error. I suggest to leave it as a warning when building and not as an error.It would be nice if the user could have control over the automations from Appodeal.